### PR TITLE
Fix frontier not detect

### DIFF
--- a/R/Binomial_LocalisedINLA.R
+++ b/R/Binomial_LocalisedINLA.R
@@ -21,8 +21,7 @@ binomial_localisedINLA <-
   inla.version= strsplit(as.character(packageVersion("INLA")),"\\.")
   inla.version= sapply(inla.version,as.numeric)
   needscontrol= (inla.version[1]<22 && inla.version[2]<7)
-  ##############################################
-  #### Overall formula object
+
   ##############################################
   #### Format the arguments and check for errors
   ##############################################

--- a/R/Binomial_LocalisedINLA.R
+++ b/R/Binomial_LocalisedINLA.R
@@ -16,6 +16,14 @@ binomial_localisedINLA <-
            prior.precision.scale = 0.001)
   {
   ##############################################
+  #### Check for INLA version to be able adapt 
+  #### call in consequences 
+  inla.version= strsplit(as.character(packageVersion("INLA")),"\\.")
+  inla.version= sapply(inla.version,as.numeric)
+  needscontrol= (inla.version[1]<22 && inla.version[2]<7)
+  ##############################################
+  #### Overall formula object
+  ##############################################
   #### Format the arguments and check for errors
   ##############################################
   #### Overall formula object
@@ -60,7 +68,9 @@ binomial_localisedINLA <-
   ###############################################
   #### Run the model
   form <- Y ~ -1 + X +  f(region, model="iid", constr=TRUE, hyper=list(theta=list(prior="loggamma", param=c(prior.precision.shape, prior.precision.scale))))
-  model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials, control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+  model = NULL
+  if(needscontrol) model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials,control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+  else model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials, control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
 
 
   #### Compute Morans I
@@ -127,10 +137,18 @@ binomial_localisedINLA <-
 
       #### Fit the model with the current W matrix
       form <- Y ~  -1 + X + f(region, model="generic0", Cmatrix = Q, constr=TRUE, hyper=list(theta=list(prior="loggamma", param=c(prior.precision.shape, prior.precision.scale))))
-      model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials,
-#                     verbose = T,
-                     control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
-
+      if(needscontrol)
+      {
+        model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials,
+#                       verbose = T,
+                       control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+      }
+      else
+      {
+        model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials,
+#                       verbose = T,
+                       control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+      }
 
       #### Compute Moran's I
       fitted <- model$summary.fitted.values[ ,4]
@@ -198,7 +216,8 @@ binomial_localisedINLA <-
 
       ## Run the final model
       form <- Y ~  -1 + X  +  f(region, model="generic0", Cmatrix = Q, constr=TRUE, hyper=list(theta=list(prior="loggamma", param=c(prior.precision.shape, prior.precision.scale))))
-      model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials, control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+      if(needscontrol) model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials, control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+      else model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials, control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
 
 
       ## Save the results
@@ -234,7 +253,8 @@ binomial_localisedINLA <-
 
       ## Run the final model
       form <- Y ~  -1 + X  +  f(region, model="generic0", Cmatrix = Q, constr=TRUE, hyper=list(theta=list(prior="loggamma", param=c(prior.precision.shape, prior.precision.scale))))
-      model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials, control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+      if(needscontrol) model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials, control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+      else model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials, control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
 
 
       ## Save the results
@@ -268,7 +288,9 @@ binomial_localisedINLA <-
 
       #### Fit the model with the current W matrix
       form <- Y ~  -1 + X +  f(region, model="generic1", Cmatrix = Q, constr=TRUE, hyper=list(theta1=list(prior="loggamma", param=c(prior.precision.shape, prior.precision.scale)), theta2=list(prior="gaussian", param=c(0, 0.01))))
-      model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials,control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+      if(needscontrol) model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials,control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+      else model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials, control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+
 
 
       #### Compute Moran's I
@@ -338,7 +360,8 @@ binomial_localisedINLA <-
 
       ## Run the final model
       form <- Y ~  -1 + X + f(region, model="generic1", Cmatrix = Q, constr=TRUE, hyper=list(theta1=list(prior="loggamma", param=c(prior.precision.shape, prior.precision.scale)), theta2=list(prior="gaussian", param=c(0, 0.01))))
-      model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials,control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+      if(needscontrol) model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials,control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+      else model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials, control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
 
 
       ## Save the results
@@ -373,7 +396,8 @@ binomial_localisedINLA <-
 
       ## Run the final model
       form <- Y ~  -1 + X  +  f(region, model="generic1", Cmatrix = Q, constr=TRUE, hyper=list(theta1=list(prior="loggamma", param=c(prior.precision.shape, prior.precision.scale)), theta2=list(prior="gaussian", param=c(0, 0.01))))
-      model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials,control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+      if(needscontrol) model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials,control.results=list(return.marginals.predictor=TRUE), control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
+      else model  =  inla(form, family="binomial", data=data.temp, Ntrials=Ntrials, control.fixed=list(mean=prior.beta.mean, mean.intercept=prior.beta.mean, prec=prior.beta.precision, prec.intercept=prior.beta.precision), control.compute=list(dic=TRUE, mlik=TRUE), control.predictor=list(compute=TRUE))
 
 
       ## Save the results

--- a/R/Binomial_LocalisedINLA.R
+++ b/R/Binomial_LocalisedINLA.R
@@ -111,11 +111,6 @@ binomial_localisedINLA <-
   #### Run the model and save the results
   #### Two possible cases depending on whether rho is fixed or estimated
   #######################################################################
-
-  #######################################################################
-  #### Run the model and save the results
-  #### Two possible cases depending on whether rho is fixed or estimated
-  #######################################################################
   if(fix.rho)
   {
     #################

--- a/R/frontier_as_sf.R
+++ b/R/frontier_as_sf.R
@@ -89,21 +89,7 @@ frontier_as_sf <-
 
     x <- proc.time()
 
-    for (i in 1:nrow(edgelist_borders)) {
-      #i <- 1 # for testing
-      zone1 <- edgelist_borders$col[i]
-      zone2 <- edgelist_borders$row[i]
-
-      borders.sf[[i]] <-
-        data.for.borders[zone1, ] %>% st_intersection(data.for.borders[zone2, ]) # now we are intersecting polys to get borders
-      #borders.sf$frontier[i] <- edgelist_borders$frontier[i]
-
-      if (!silent & (i %% 10 == 0)) {
-        print(i)
-      }
-
-    }
-
+    borders.sf=apply(edgelist_borders,1,function(edge) st_intersection(data.for.borders[edge, ])[2,]) 
 
     borders.sf <-
       do.call(rbind, borders.sf)
@@ -123,7 +109,7 @@ frontier_as_sf <-
       ## Fix multiple entries caused by geom_collections -- eg. multiple intersections
       borders.sf <-
         borders.sf %>%
-        group_by(id, id.1, phi, phi.1) %>%
+        group_by(id, phi) %>%
         summarise(
           hotfix = T
         ) %>%


### PR DESCRIPTION
Working on solving #15 this branch propose to change the call of `st_intersection`. I am still not sure how `sf_interesection` works, and I use here an apply that simplify the for loop (and should also increase the speed of `frontier_as_sf`) using a hack by taking the second line of the object return by `sf_intersection` when using with a the set of polygons between which I want to find the border. Problem is that doing it this way, the `id.1` and `phi.1` previously manually stored are lost. Something could be done if they need to be kept but if they don't, I think this is a more elegant solution (and the `apply` could be parallelised in case of huge number of frontier to extract). 
Nonetheless, this solve #15, [this vignette](https://github.com/MengLeZhang/socialFrontiers/blob/master/vignettes/Detecting-frontiers-in-Barnet.Rmd) compile with still exactly the same results and now make `frontier_as_sf` working with my different shapefile. 